### PR TITLE
Improve sync and fix issues

### DIFF
--- a/facade-lib/include/facade/scene/scene.hpp
+++ b/facade-lib/include/facade/scene/scene.hpp
@@ -44,6 +44,7 @@ class Scene {
 	bool load_gltf(std::string_view path);
 
 	Id<Camera> add(Camera camera);
+	Id<Sampler> add(Sampler sampler);
 	Id<Material> add(std::unique_ptr<Material> material);
 	Id<StaticMesh> add(StaticMesh mesh);
 	Id<Image> add(Image image);
@@ -62,7 +63,7 @@ class Scene {
 	bool select_camera(Id<Camera> id);
 	Node& camera();
 
-	vk::Sampler sampler() const { return *m_sampler; }
+	vk::Sampler sampler() const { return m_sampler.sampler(); }
 	Texture make_texture(Image::View image) const;
 
 	void write_view(Pipeline& out_pipeline) const;
@@ -101,6 +102,7 @@ class Scene {
 
 	struct Storage {
 		std::vector<Camera> cameras{};
+		std::vector<Sampler> samplers{};
 		std::vector<std::unique_ptr<Material>> materials{};
 		std::vector<StaticMesh> static_meshes{};
 		std::vector<Image> images{};
@@ -124,7 +126,7 @@ class Scene {
 	void check(Node const& node) const noexcept(false);
 
 	Gfx m_gfx;
-	vk::UniqueSampler m_sampler;
+	Sampler m_sampler;
 	Buffer m_view_proj;
 	Buffer m_dir_lights;
 	Texture m_white;

--- a/facade-lib/include/facade/util/defer_queue.hpp
+++ b/facade-lib/include/facade/util/defer_queue.hpp
@@ -10,6 +10,8 @@ class DeferQueue {
 	DeferQueue() = default;
 	DeferQueue& operator=(DeferQueue&&) = delete;
 
+	~DeferQueue() { clear(); }
+
 	template <typename T>
 	void push(T t) {
 		auto lock = std::scoped_lock{m_mutex};
@@ -19,6 +21,11 @@ class DeferQueue {
 	void next() {
 		auto lock = std::scoped_lock{m_mutex};
 		m_stack.next();
+	}
+
+	void clear() {
+		auto lock = std::scoped_lock{m_mutex};
+		m_stack = {};
 	}
 
   private:

--- a/facade-lib/include/facade/vk/buffer.hpp
+++ b/facade-lib/include/facade/vk/buffer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <facade/util/ring_buffer.hpp>
+#include <facade/vk/defer.hpp>
 #include <facade/vk/gfx.hpp>
 #include <vector>
 
@@ -30,7 +31,7 @@ class Buffer {
 
   private:
 	Gfx m_gfx{};
-	mutable RingBuffer<UniqueBuffer> m_buffers{};
+	mutable RingBuffer<Defer<UniqueBuffer>> m_buffers{};
 	std::vector<std::byte> m_data{};
 	std::size_t m_size{};
 	Type m_type{};

--- a/facade-lib/include/facade/vk/gfx.hpp
+++ b/facade-lib/include/facade/vk/gfx.hpp
@@ -5,9 +5,14 @@
 namespace facade {
 struct Gfx {
 	struct Shared {
+		struct DeviceBlock {
+			vk::Device device;
+			~DeviceBlock() { device.waitIdle(); }
+		};
 		vk::PhysicalDeviceLimits device_limits{};
 		DeferQueue defer_queue{};
 		std::mutex mutex{};
+		DeviceBlock block{};
 	};
 
 	Vma vma{};

--- a/facade-lib/include/facade/vk/texture.hpp
+++ b/facade-lib/include/facade/vk/texture.hpp
@@ -6,17 +6,23 @@
 #include <span>
 
 namespace facade {
+struct SamplerCreateInfo {
+	vk::SamplerAddressMode mode_s{vk::SamplerAddressMode::eRepeat};
+	vk::SamplerAddressMode mode_t{vk::SamplerAddressMode::eRepeat};
+	vk::Filter min{vk::Filter::eLinear};
+	vk::Filter mag{vk::Filter::eLinear};
+};
+
+struct TextureCreateInfo {
+	bool mip_mapped{true};
+	ColourSpace colour_space{ColourSpace::eSrgb};
+};
+
 class Sampler {
   public:
-	struct CreateInfo {
-		Gfx gfx{};
-		vk::SamplerAddressMode mode_s{vk::SamplerAddressMode::eRepeat};
-		vk::SamplerAddressMode mode_t{vk::SamplerAddressMode::eRepeat};
-		vk::Filter min{vk::Filter::eLinear};
-		vk::Filter mag{vk::Filter::eLinear};
-	};
+	using CreateInfo = SamplerCreateInfo;
 
-	explicit Sampler(CreateInfo const& info);
+	explicit Sampler(Gfx const& gfx, CreateInfo const& info = {});
 
 	vk::Sampler sampler() const { return *m_sampler.get(); }
 
@@ -26,18 +32,11 @@ class Sampler {
 
 class Texture {
   public:
-	struct CreateInfo {
-		Gfx gfx{};
-		vk::Sampler sampler{};
-
-		bool mip_mapped{true};
-		ColourSpace colour_space{ColourSpace::eSrgb};
-	};
+	using CreateInfo = TextureCreateInfo;
 
 	static std::uint32_t mip_levels(vk::Extent2D extent);
-	static vk::UniqueSampler make_sampler(Gfx const& gfx, vk::SamplerAddressMode mode, vk::Filter filter = vk::Filter::eLinear);
 
-	Texture(CreateInfo const& info, Image::View image);
+	Texture(Gfx const& gfx, vk::Sampler sampler, Image::View image, CreateInfo const& info = {});
 
 	ImageView view() const { return m_image.get().get().image_view(); }
 	DescriptorImage descriptor_image() const { return {*m_image.get().get().view, sampler}; }

--- a/facade-lib/include/facade/vk/texture.hpp
+++ b/facade-lib/include/facade/vk/texture.hpp
@@ -6,6 +6,24 @@
 #include <span>
 
 namespace facade {
+class Sampler {
+  public:
+	struct CreateInfo {
+		Gfx gfx{};
+		vk::SamplerAddressMode mode_s{vk::SamplerAddressMode::eRepeat};
+		vk::SamplerAddressMode mode_t{vk::SamplerAddressMode::eRepeat};
+		vk::Filter min{vk::Filter::eLinear};
+		vk::Filter mag{vk::Filter::eLinear};
+	};
+
+	explicit Sampler(CreateInfo const& info);
+
+	vk::Sampler sampler() const { return *m_sampler.get(); }
+
+  private:
+	Defer<vk::UniqueSampler> m_sampler{};
+};
+
 class Texture {
   public:
 	struct CreateInfo {

--- a/facade-lib/src/detail/gltf.hpp
+++ b/facade-lib/src/detail/gltf.hpp
@@ -16,6 +16,21 @@ namespace facade {
 struct DataProvider;
 
 namespace gltf {
+enum class Filter {
+	eNearest = 9728,
+	eLinear = 9729,
+	eNearestMipmapNearest = 9984,
+	eLinearMipmapNearest = 9985,
+	eNearestMipmapLinear = 9986,
+	eLinearMipmapLinear = 9987,
+};
+
+enum class Wrap {
+	eClampEdge = 33071,
+	eMirrorRepeat = 33648,
+	eRepeat = 10497,
+};
+
 struct TextureInfo {
 	std::size_t texture{};
 	std::size_t tex_coord{};
@@ -87,6 +102,20 @@ struct Camera {
 	Type type{};
 };
 
+struct Sampler {
+	std::string name{};
+	std::optional<Filter> min_filter{};
+	std::optional<Filter> mag_filter{};
+	Wrap wrap_s{Wrap::eRepeat};
+	Wrap wrap_t{Wrap::eRepeat};
+};
+
+struct Texture {
+	std::string name{};
+	std::optional<std::size_t> sampler{};
+	std::size_t source{};
+};
+
 struct Node {
 	enum class Type { eNone, eMesh, eCamera };
 
@@ -102,8 +131,10 @@ struct Scene {
 
 struct Asset {
 	std::vector<Camera> cameras{};
+	std::vector<Sampler> samplers{};
 	std::vector<Geometry> geometries{};
 	std::vector<Image> images{};
+	std::vector<Texture> textures{};
 	std::vector<Material> materials{};
 	std::vector<Mesh> meshes{};
 	std::vector<Node> nodes{};

--- a/facade-lib/src/scene/renderer.cpp
+++ b/facade-lib/src/scene/renderer.cpp
@@ -67,6 +67,7 @@ bool Renderer::next_frame(std::span<vk::CommandBuffer> out) {
 	if (m_impl->swapchain.acquire(m_impl->window.framebuffer_extent(), acquired, *frame.sync.draw) != vk::Result::eSuccess) { return false; }
 	m_impl->gfx.reset(*frame.sync.drawn);
 	m_impl->dear_imgui.new_frame();
+	m_impl->gfx.shared->defer_queue.next();
 
 	m_impl->render_target = m_impl->render_pass.refresh(acquired);
 

--- a/facade-lib/src/scene/scene.cpp
+++ b/facade-lib/src/scene/scene.cpp
@@ -48,12 +48,12 @@ constexpr vk::Filter to_filter(gltf::Filter const filter) {
 }
 
 Sampler to_sampler(Gfx const& gfx, gltf::Sampler const& sampler) {
-	auto info = Sampler::CreateInfo{gfx};
+	auto info = Sampler::CreateInfo{};
 	info.mode_s = to_address_mode(sampler.wrap_s);
 	info.mode_t = to_address_mode(sampler.wrap_t);
 	if (sampler.min_filter) { info.min = to_filter(*sampler.min_filter); }
 	if (sampler.mag_filter) { info.mag = to_filter(*sampler.mag_filter); }
-	return Sampler{info};
+	return Sampler{gfx, info};
 }
 
 std::unique_ptr<Material> to_material(gltf::Material const& material) {
@@ -176,8 +176,8 @@ bool Scene::load_gltf(dj::Json const& root, DataProvider const& provider) noexce
 }
 
 Scene::Scene(Gfx const& gfx)
-	: m_gfx(gfx), m_sampler(Sampler::CreateInfo{gfx}), m_view_proj(gfx, Buffer::Type::eUniform), m_dir_lights(gfx, Buffer::Type::eStorage),
-	  m_white(Texture::CreateInfo{gfx, m_sampler.sampler(), false}, Img1x1::make({0xff, 0xff, 0xff, 0xff}).view()) {}
+	: m_gfx(gfx), m_sampler(gfx), m_view_proj(gfx, Buffer::Type::eUniform), m_dir_lights(gfx, Buffer::Type::eStorage),
+	  m_white(gfx, m_sampler.sampler(), Img1x1::make({0xff, 0xff, 0xff, 0xff}).view(), Texture::CreateInfo{.mip_mapped = false}) {}
 
 Id<Camera> Scene::add(Camera camera) {
 	auto const id = m_storage.cameras.size();
@@ -243,7 +243,7 @@ Node& Scene::camera() {
 	return *ret;
 }
 
-Texture Scene::make_texture(Image::View image) const { return Texture{Texture::CreateInfo{m_gfx, sampler()}, image}; }
+Texture Scene::make_texture(Image::View image) const { return Texture{m_gfx, sampler(), image}; }
 
 void Scene::write_view(Pipeline& out_pipeline) const {
 	auto& set0 = out_pipeline.next_set(0);
@@ -326,7 +326,7 @@ void Scene::render(Renderer& renderer, vk::CommandBuffer cb, Node const& node, g
 			auto& ret = scene.m_storage.textures[index][colour_space];
 			if (!ret) {
 				assert(index < scene.m_storage.images.size());
-				ret.emplace(Texture::CreateInfo{scene.m_gfx, scene.sampler(), true, colour_space}, scene.m_storage.images[index]);
+				ret.emplace(scene.m_gfx, scene.sampler(), scene.m_storage.images[index], Texture::CreateInfo{true, colour_space});
 			}
 			return &*ret;
 		}

--- a/facade-lib/src/scene/scene.cpp
+++ b/facade-lib/src/scene/scene.cpp
@@ -30,6 +30,32 @@ Camera to_camera(gltf::Camera cam) {
 	return ret;
 }
 
+constexpr vk::SamplerAddressMode to_address_mode(gltf::Wrap const wrap) {
+	switch (wrap) {
+	case gltf::Wrap::eClampEdge: return vk::SamplerAddressMode::eClampToEdge;
+	case gltf::Wrap::eMirrorRepeat: return vk::SamplerAddressMode::eMirroredRepeat;
+	default:
+	case gltf::Wrap::eRepeat: return vk::SamplerAddressMode::eRepeat;
+	}
+}
+
+constexpr vk::Filter to_filter(gltf::Filter const filter) {
+	switch (filter) {
+	default:
+	case gltf::Filter::eLinear: return vk::Filter::eLinear;
+	case gltf::Filter::eNearest: return vk::Filter::eNearest;
+	}
+}
+
+Sampler to_sampler(Gfx const& gfx, gltf::Sampler const& sampler) {
+	auto info = Sampler::CreateInfo{gfx};
+	info.mode_s = to_address_mode(sampler.wrap_s);
+	info.mode_t = to_address_mode(sampler.wrap_t);
+	if (sampler.min_filter) { info.min = to_filter(*sampler.min_filter); }
+	if (sampler.mag_filter) { info.mag = to_filter(*sampler.mag_filter); }
+	return Sampler{info};
+}
+
 std::unique_ptr<Material> to_material(gltf::Material const& material) {
 	auto ret = std::make_unique<TestMaterial>();
 	ret->albedo = material.pbr.base_colour_factor;
@@ -136,6 +162,7 @@ bool Scene::load_gltf(dj::Json const& root, DataProvider const& provider) noexce
 
 	m_storage.images = std::move(asset.images);
 	m_storage.textures.resize(m_storage.images.size());
+	for (auto const& sampler : asset.samplers) { add(to_sampler(m_gfx, sampler)); }
 	for (auto const& material : asset.materials) { add(to_material(material)); }
 	for (auto const& geometry : asset.geometries) { add(StaticMesh{m_gfx, geometry}); }
 	for (auto const& mesh : asset.meshes) { add(to_mesh(mesh)); }
@@ -149,12 +176,18 @@ bool Scene::load_gltf(dj::Json const& root, DataProvider const& provider) noexce
 }
 
 Scene::Scene(Gfx const& gfx)
-	: m_gfx(gfx), m_sampler(Texture::make_sampler(gfx, vk::SamplerAddressMode::eClampToEdge)), m_view_proj(gfx, Buffer::Type::eUniform),
-	  m_dir_lights(gfx, Buffer::Type::eStorage), m_white(Texture::CreateInfo{gfx, *m_sampler, false}, Img1x1::make({0xff, 0xff, 0xff, 0xff}).view()) {}
+	: m_gfx(gfx), m_sampler(Sampler::CreateInfo{gfx}), m_view_proj(gfx, Buffer::Type::eUniform), m_dir_lights(gfx, Buffer::Type::eStorage),
+	  m_white(Texture::CreateInfo{gfx, m_sampler.sampler(), false}, Img1x1::make({0xff, 0xff, 0xff, 0xff}).view()) {}
 
 Id<Camera> Scene::add(Camera camera) {
 	auto const id = m_storage.cameras.size();
 	m_storage.cameras.push_back(std::move(camera));
+	return id;
+}
+
+Id<Sampler> Scene::add(Sampler sampler) {
+	auto const id = m_storage.samplers.size();
+	m_storage.samplers.push_back(std::move(sampler));
 	return id;
 }
 

--- a/facade-lib/src/vk/buffer.cpp
+++ b/facade-lib/src/vk/buffer.cpp
@@ -29,17 +29,17 @@ void Buffer::rotate() { m_buffers.rotate(); }
 
 void Buffer::refresh() const {
 	auto& buffer = m_buffers.get();
-	if (m_data.size() > buffer.get().size) { buffer = m_gfx.vma.make_buffer(get_usage(m_type), m_data.size(), true); }
-	std::memcpy(buffer.get().ptr, m_data.data(), m_data.size());
+	if (m_data.size() > buffer.get().get().size) { buffer = {m_gfx.vma.make_buffer(get_usage(m_type), m_data.size(), true), m_gfx.shared->defer_queue}; }
+	std::memcpy(buffer.get().get().ptr, m_data.data(), m_data.size());
 }
 
 BufferView Buffer::view() const {
 	refresh();
-	return {m_buffers.get().get().buffer, m_size};
+	return {m_buffers.get().get().get().buffer, m_size};
 }
 
 DescriptorBuffer Buffer::descriptor_buffer() const {
 	refresh();
-	return {m_buffers.get().get().buffer, m_buffers.get().get().size, to_descriptor_type(m_type)};
+	return {m_buffers.get().get().get().buffer, m_buffers.get().get().get().size, to_descriptor_type(m_type)};
 }
 } // namespace facade

--- a/facade-lib/src/vk/render_frame.cpp
+++ b/facade-lib/src/vk/render_frame.cpp
@@ -28,12 +28,12 @@ ImageBarrier undef_to_colour(ImageView const& image) {
 
 ImageBarrier undef_to_depth(ImageView const& image) {
 	auto ret = ImageBarrier{};
-	ret.barrier.dstAccessMask = vk::AccessFlagBits::eDepthStencilAttachmentWrite | vk::AccessFlagBits::eDepthStencilAttachmentRead;
+	ret.barrier.srcAccessMask = ret.barrier.dstAccessMask = vk::AccessFlagBits::eDepthStencilAttachmentWrite | vk::AccessFlagBits::eDepthStencilAttachmentRead;
 	ret.barrier.oldLayout = vk::ImageLayout::eUndefined;
 	ret.barrier.newLayout = vk::ImageLayout::eDepthAttachmentOptimal;
 	ret.barrier.image = image.image;
 	ret.barrier.subresourceRange = {vk::ImageAspectFlagBits::eDepth, 0, 1, 0, 1};
-	ret.stages = {vk::PipelineStageFlagBits::eTopOfPipe, vk::PipelineStageFlagBits::eEarlyFragmentTests | vk::PipelineStageFlagBits::eLateFragmentTests};
+	ret.stages.first = ret.stages.second = vk::PipelineStageFlagBits::eEarlyFragmentTests | vk::PipelineStageFlagBits::eLateFragmentTests;
 	return ret;
 }
 

--- a/facade-lib/src/vk/texture.cpp
+++ b/facade-lib/src/vk/texture.cpp
@@ -88,6 +88,21 @@ bool can_mip(vk::PhysicalDevice const gpu, vk::Format const format) {
 }
 } // namespace
 
+Sampler::Sampler(CreateInfo const& info) {
+	auto sci = vk::SamplerCreateInfo{};
+	sci.minFilter = info.min;
+	sci.magFilter = info.mag;
+	sci.anisotropyEnable = info.gfx.shared->device_limits.maxSamplerAnisotropy > 0.0f;
+	sci.maxAnisotropy = info.gfx.shared->device_limits.maxSamplerAnisotropy;
+	sci.borderColor = vk::BorderColor::eIntOpaqueBlack;
+	sci.mipmapMode = vk::SamplerMipmapMode::eNearest;
+	sci.addressModeU = info.mode_s;
+	sci.addressModeV = info.mode_t;
+	sci.addressModeW = info.mode_s;
+	sci.maxLod = VK_LOD_CLAMP_NONE;
+	m_sampler = {info.gfx.device.createSamplerUnique(sci), info.gfx.shared->defer_queue};
+}
+
 std::uint32_t Texture::mip_levels(vk::Extent2D extent) { return static_cast<std::uint32_t>(std::floor(std::log2(std::max(extent.width, extent.height)))) + 1U; }
 
 vk::UniqueSampler Texture::make_sampler(Gfx const& gfx, vk::SamplerAddressMode const mode, vk::Filter const filter) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,7 @@ Vulkan make_vulkan(Glfw::Window const& window) {
 	ret.device = Vulkan::Device::make(ret.instance, *surface);
 	ret.vma = Vulkan::make_vma(*ret.instance.instance, ret.device.gpu.device, *ret.device.device);
 	ret.shared = std::make_unique<Gfx::Shared>();
+	ret.shared->block.device = *ret.device.device;
 	ret.shared->device_limits = ret.device.gpu.properties.limits;
 	return ret;
 }


### PR DESCRIPTION
- Defer `Buffer` resources.
- Add `Sampler` to wrap `Defer<UniqueSampler>`.
- Parse sampler data from GLTF - currently unused.
- Fix depth image sync issues.