### PR TITLE
Incorporate samplers from GLTF data into textures

### DIFF
--- a/facade-lib/include/facade/scene/material.hpp
+++ b/facade-lib/include/facade/scene/material.hpp
@@ -11,15 +11,11 @@ namespace facade {
 class Texture;
 class Pipeline;
 
-struct TextureProvider {
-	virtual Texture const* get(std::size_t index, ColourSpace colour_space) const = 0;
-};
-
 struct TextureStore {
+	std::span<Texture const> textures;
 	Texture const& white;
-	TextureProvider const& provider;
 
-	Texture const& get(std::optional<std::size_t> index, ColourSpace colour_space) const;
+	Texture const& get(std::optional<std::size_t> index) const;
 };
 
 class Material {
@@ -43,7 +39,7 @@ class UnlitMaterial : public Material {
 	void write_sets(Pipeline& pipeline, TextureStore const& store) const override;
 };
 
-class TestMaterial : public Material {
+class LitMaterial : public Material {
   public:
 	glm::vec3 albedo{1.0f};
 	float metallic{0.5f};

--- a/facade-lib/include/facade/scene/material.hpp
+++ b/facade-lib/include/facade/scene/material.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <facade/scene/id.hpp>
 #include <facade/util/colour_space.hpp>
+#include <facade/vk/texture.hpp>
 #include <glm/vec3.hpp>
 #include <glm/vec4.hpp>
 #include <optional>
@@ -8,7 +9,6 @@
 #include <string>
 
 namespace facade {
-class Texture;
 class Pipeline;
 
 struct TextureStore {

--- a/facade-lib/include/facade/scene/scene.hpp
+++ b/facade-lib/include/facade/scene/scene.hpp
@@ -63,7 +63,7 @@ class Scene {
 	bool select_camera(Id<Camera> id);
 	Node& camera();
 
-	vk::Sampler sampler() const { return m_sampler.sampler(); }
+	vk::Sampler default_sampler() const { return m_sampler.sampler(); }
 	Texture make_texture(Image::View image) const;
 
 	void write_view(Pipeline& out_pipeline) const;
@@ -98,15 +98,13 @@ class Scene {
 		std::vector<Tree::Data> trees{};
 	};
 
-	using Tex = EnumArray<ColourSpace, std::optional<Texture>, 2>;
-
 	struct Storage {
 		std::vector<Camera> cameras{};
 		std::vector<Sampler> samplers{};
 		std::vector<std::unique_ptr<Material>> materials{};
 		std::vector<StaticMesh> static_meshes{};
 		std::vector<Image> images{};
-		std::vector<Tex> textures{};
+		std::vector<Texture> textures{};
 		std::vector<Mesh> meshes{};
 		std::vector<glm::mat4x4> instances{};
 		Data data{};

--- a/facade-lib/src/detail/gltf.cpp
+++ b/facade-lib/src/detail/gltf.cpp
@@ -479,6 +479,21 @@ struct Data {
 			for (auto const& m : scene["materials"].array_view()) { material(m); }
 
 			for (auto const& m : scene["meshes"].array_view()) { mesh(m); }
+
+			// Texture will use ColourSpace::sRGB by default; change non-colour textures to be linear
+			auto set_linear = [this](std::size_t index) { storage.textures.at(index).colour_space = ColourSpace::eLinear; };
+
+			// Determine whether a texture points to colour data by referring to the material(s) it is used in
+			// In our case all material textures except pbr.base_colour_texture are linear
+			// The GLTF spec mandates image formats for corresponding material textures:
+			// https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-material
+			for (auto const& m : storage.materials) {
+				if (m.pbr.metallic_roughness_texture) { set_linear(m.pbr.metallic_roughness_texture->texture); }
+				if (m.emissive_texture) { set_linear(m.emissive_texture->texture); }
+				if (m.occlusion_texture) { set_linear(m.occlusion_texture->info.texture); }
+				if (m.normal_texture) { set_linear(m.normal_texture->info.texture); }
+			}
+
 			return std::move(storage);
 		}
 	};

--- a/facade-lib/src/detail/gltf.hpp
+++ b/facade-lib/src/detail/gltf.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <facade/scene/transform.hpp>
 #include <facade/util/byte_buffer.hpp>
+#include <facade/util/colour_space.hpp>
 #include <facade/util/geometry.hpp>
 #include <facade/util/image.hpp>
 #include <glm/vec4.hpp>
@@ -114,6 +115,15 @@ struct Texture {
 	std::string name{};
 	std::optional<std::size_t> sampler{};
 	std::size_t source{};
+
+	///
+	/// \brief Describes whether to load the source image in sRGB or linear format
+	///
+	/// Textures with colour info are sRGB encoeded, with other info (eg normal data) are linear encoded
+	/// This information is obtained from the material(s) textures are used in
+	/// Different materials using the same texture as colour and non-colour sources is undefined behaviour
+	///
+	ColourSpace colour_space{ColourSpace::eSrgb};
 };
 
 struct Node {

--- a/facade-lib/src/detail/gltf.hpp
+++ b/facade-lib/src/detail/gltf.hpp
@@ -119,7 +119,7 @@ struct Texture {
 	///
 	/// \brief Describes whether to load the source image in sRGB or linear format
 	///
-	/// Textures with colour info are sRGB encoeded, with other info (eg normal data) are linear encoded
+	/// Textures with colour info are sRGB encoded, with other info (eg normal data) are linear encoded
 	/// This information is obtained from the material(s) textures are used in
 	/// Different materials using the same texture as colour and non-colour sources is undefined behaviour
 	///

--- a/facade-lib/src/scene/material.cpp
+++ b/facade-lib/src/scene/material.cpp
@@ -13,15 +13,14 @@ struct Mat {
 glm::vec4 uncorrect(glm::vec4 const& in) { return glm::convertSRGBToLinear(in); }
 } // namespace
 
-Texture const& TextureStore::get(std::optional<std::size_t> const index, ColourSpace const colour_space) const {
-	if (!index) { return white; }
-	if (auto const* ret = provider.get(*index, colour_space)) { return *ret; }
-	return white;
+Texture const& TextureStore::get(std::optional<std::size_t> const index) const {
+	if (!index || *index >= textures.size()) { return white; }
+	return textures[*index];
 }
 
 void UnlitMaterial::write_sets(Pipeline& pipeline, TextureStore const& store) const {
 	auto& set1 = pipeline.next_set(1);
-	set1.update(0, store.get(texture, ColourSpace::eSrgb).descriptor_image());
+	set1.update(0, store.get(texture).descriptor_image());
 	auto& set2 = pipeline.next_set(2);
 	auto const mat = Mat{
 		.albedo = uncorrect(tint),
@@ -32,10 +31,10 @@ void UnlitMaterial::write_sets(Pipeline& pipeline, TextureStore const& store) co
 	pipeline.bind(set2);
 }
 
-void TestMaterial::write_sets(Pipeline& pipeline, TextureStore const& store) const {
+void LitMaterial::write_sets(Pipeline& pipeline, TextureStore const& store) const {
 	auto& set1 = pipeline.next_set(1);
-	set1.update(0, store.get(base_colour, ColourSpace::eSrgb).descriptor_image());
-	set1.update(1, store.get(roughness_metallic, ColourSpace::eLinear).descriptor_image());
+	set1.update(0, store.get(base_colour).descriptor_image());
+	set1.update(1, store.get(roughness_metallic).descriptor_image());
 	auto& set2 = pipeline.next_set(2);
 	auto const mat = Mat{
 		.albedo = uncorrect({albedo, 1.0f}),

--- a/facade-lib/src/scene/material.cpp
+++ b/facade-lib/src/scene/material.cpp
@@ -1,6 +1,5 @@
 #include <facade/scene/material.hpp>
 #include <facade/vk/pipeline.hpp>
-#include <facade/vk/texture.hpp>
 #include <glm/gtc/color_space.hpp>
 
 namespace facade {

--- a/facade-lib/src/util/data_provider.cpp
+++ b/facade-lib/src/util/data_provider.cpp
@@ -20,7 +20,7 @@ FileDataProvider::FileDataProvider(std::string_view directory) {
 	m_directory = path.generic_string();
 }
 
-FileDataProvider FileDataProvider::mount_parent_dir(std::string_view filename) { return {fs::path{filename}.parent_path().generic_string()}; }
+FileDataProvider FileDataProvider::mount_parent_dir(std::string_view filename) { return FileDataProvider{fs::path{filename}.parent_path().generic_string()}; }
 
 ByteBuffer FileDataProvider::load(std::string_view uri) const {
 	auto const path = absolute_path(m_directory, uri);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,7 +181,7 @@ void run() {
 	auto post_scene_load = [&] {
 		scene.camera().transform.set_position({0.0f, 0.0f, 5.0f});
 
-		auto material = std::make_unique<TestMaterial>();
+		auto material = std::make_unique<LitMaterial>();
 		material->albedo = {1.0f, 0.0f, 0.0f};
 		material_id = scene.add(std::move(material));
 		auto static_mesh_id = scene.add(StaticMesh{gfx, make_cubed_sphere(1.0f, 32)});
@@ -243,7 +243,7 @@ void run() {
 
 		ImGui::SetNextWindowSize({250.0f, 100.0f}, ImGuiCond_Once);
 		if (ImGui::Begin("Material")) {
-			auto* mat = static_cast<TestMaterial*>(scene.find_material(material_id));
+			auto* mat = static_cast<LitMaterial*>(scene.find_material(material_id));
 			ImGui::SliderFloat("Metallic", &mat->metallic, 0.0f, 1.0f);
 			ImGui::SliderFloat("Roughness", &mat->roughness, 0.0f, 1.0f);
 		}


### PR DESCRIPTION
### Context

This PR addresses two broad points:
1. Using samplers created from GLTF data for textures.
1. Replacing the ad-hoc on demand texture creation approach with one where all textures are created when the scene is parsed: this improves rendering stability and enables async loading of textures.

#### Bonus!

It appears that the changes here also close #12!

![Screenshot_20221021_201145](https://user-images.githubusercontent.com/16272243/197316549-476ba33f-b281-4172-9a33-24b9b11885d4.png)

### Background

Colour spaces are a complicated rabbit hole, for this PR just being aware that the same image data can be interpreted in two different ways by textures in Vulkan (sRGB vs linear) is sufficient.

Textures were being created on demand because there's no direct way to know whether one should be in sRGB or linear format: this decision was deferred all the way to a `Material` requesting a texture of the corresponding format at render time. This PR uses the [GLTF material spec](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-material) to encode the desired colour space of each texture in the returned GLTF scene data, which is then used by `Scene` to create corresponding textures right after parsing that data.

### Changes

- Replace on-demand texture creation with material-based `ColourSpace` decisions.
- Remove `TextureProvider`.
- Add check for `Id<Camera>` if attached to `Node` being added.
- Rename `TestMaterial` to `LitMaterial`.

Close #16 