### PR TITLE
Add editor::Inspector

### DIFF
--- a/facade-lib/CMakeLists.txt
+++ b/facade-lib/CMakeLists.txt
@@ -75,6 +75,7 @@ target_sources(${PROJECT_NAME} PRIVATE
   include/facade/util/logger.hpp
   include/facade/util/mufo.hpp
   include/facade/util/nvec3.hpp
+  include/facade/util/pinned.hpp
   include/facade/util/ring_buffer.hpp
   include/facade/util/string.hpp
   include/facade/util/time.hpp
@@ -121,6 +122,9 @@ target_sources(${PROJECT_NAME} PRIVATE
   include/facade/scene/scene.hpp
   include/facade/scene/transform.hpp
 
+  include/facade/editor/common.hpp
+  include/facade/editor/inspector.hpp
+
   src/util/data_provider.cpp
   src/util/geometry.cpp
   src/util/image.cpp
@@ -159,4 +163,7 @@ target_sources(${PROJECT_NAME} PRIVATE
   src/scene/material.cpp
   src/scene/scene.cpp
   src/scene/transform.cpp
+
+  src/editor/common.cpp
+  src/editor/inspector.cpp
 )

--- a/facade-lib/include/facade/dear_imgui/dear_imgui.hpp
+++ b/facade-lib/include/facade/dear_imgui/dear_imgui.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <imgui.h>
 #include <facade/glfw/glfw.hpp>
+#include <facade/util/colour_space.hpp>
 #include <facade/vk/gfx.hpp>
 
 namespace facade {
@@ -11,6 +12,7 @@ class DearImgui {
 		Glfw::Window window{};
 		vk::RenderPass render_pass{};
 		vk::SampleCountFlagBits samples{vk::SampleCountFlagBits::e1};
+		ColourSpace swapchain{ColourSpace::eSrgb};
 	};
 
 	DearImgui(Info const& info);

--- a/facade-lib/include/facade/editor/common.hpp
+++ b/facade-lib/include/facade/editor/common.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include <facade/util/pinned.hpp>
+
+namespace facade::editor {
+class Window : public Pinned {
+  public:
+	explicit Window(char const* label, bool* open_if = {}, int flags = {});
+	~Window();
+
+	bool is_open() const { return m_open; }
+	explicit operator bool() const { return is_open(); }
+
+  private:
+	bool m_open{};
+};
+
+class TreeNode : public Pinned {
+  public:
+	explicit TreeNode(char const* label, int flags = {});
+	~TreeNode();
+
+	bool is_open() const { return m_open; }
+	explicit operator bool() const { return is_open(); }
+
+  private:
+	bool m_open{};
+};
+} // namespace facade::editor

--- a/facade-lib/include/facade/editor/inspector.hpp
+++ b/facade-lib/include/facade/editor/inspector.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include <facade/editor/common.hpp>
+#include <facade/scene/material.hpp>
+#include <facade/scene/node.hpp>
+#include <limits>
+
+namespace facade {
+struct Mesh;
+class Scene;
+
+namespace editor {
+///
+/// \brief ImGui helper to inspect / reflect various properties
+///
+class Inspector {
+  public:
+	static constexpr auto min_v{-std::numeric_limits<float>::max()};
+	static constexpr auto max_v{std::numeric_limits<float>::max()};
+
+	///
+	/// \brief Construct an Inspector instance
+	///
+	/// Inspectors don't do anything on construction, constructors exist to enforce invariants instance-wide.
+	/// For all Inspectors, an existing Window target is required, Inspector instances will not create any
+	/// Note: target must be open
+	///
+	Inspector(Window const& target);
+
+	bool inspect(char const* label, glm::vec2& out_vec2, float speed = 1.0f, float lo = min_v, float hi = max_v) const;
+	bool inspect(char const* label, glm::vec3& out_vec3, float speed = 1.0f, float lo = min_v, float hi = max_v) const;
+	bool inspect(char const* label, glm::vec4& out_vec4, float speed = 1.0f, float lo = min_v, float hi = max_v) const;
+	bool inspect(char const* label, glm::quat& out_quat) const;
+	bool inspect(Transform& out_transform) const;
+};
+
+class SceneInspector : public Inspector {
+  public:
+	using Inspector::inspect;
+
+	SceneInspector(Window const& target, Scene& scene);
+
+	bool inspect(TreeNode const& node, UnlitMaterial& out_material) const;
+	bool inspect(TreeNode const& node, LitMaterial& out_material) const;
+	bool inspect(Id<Material> material_id) const;
+	bool inspect(Id<Node> node_id) const;
+
+	bool inspect(Id<Mesh> mesh) const;
+
+  private:
+	Scene& m_scene;
+};
+} // namespace editor
+} // namespace facade

--- a/facade-lib/include/facade/scene/id.hpp
+++ b/facade-lib/include/facade/scene/id.hpp
@@ -5,6 +5,8 @@ namespace facade {
 template <typename T>
 class Id {
   public:
+	using id_type = std::size_t;
+
 	constexpr Id(std::size_t value = {}) : m_value(value) {}
 
 	constexpr std::size_t value() const { return m_value; }

--- a/facade-lib/include/facade/scene/material.hpp
+++ b/facade-lib/include/facade/scene/material.hpp
@@ -20,6 +20,9 @@ struct TextureStore {
 
 class Material {
   public:
+	static glm::vec4 to_linear(glm::vec4 const& srgb);
+	static glm::vec4 to_srgb(glm::vec4 const& linear);
+
 	inline static std::string const default_shader_id{"default"};
 
 	virtual ~Material() = default;

--- a/facade-lib/include/facade/scene/scene.hpp
+++ b/facade-lib/include/facade/scene/scene.hpp
@@ -58,6 +58,7 @@ class Scene {
 	Node const* find_node(Id<Node> id) const;
 	Node* find_node(Id<Node> id);
 	Material* find_material(Id<Material> id) const;
+	Mesh const* find_mesh(Id<Mesh> id) const;
 
 	std::size_t camera_count() const { return m_storage.cameras.size(); }
 	bool select_camera(Id<Camera> id);

--- a/facade-lib/include/facade/util/pinned.hpp
+++ b/facade-lib/include/facade/util/pinned.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace facade {
+class Pinned {
+  public:
+	Pinned() = default;
+	Pinned(Pinned&&) = delete;
+	Pinned& operator=(Pinned&&) = delete;
+	Pinned(Pinned const&) = delete;
+	Pinned& operator=(Pinned const&) = delete;
+};
+} // namespace facade

--- a/facade-lib/include/facade/vk/swapchain.hpp
+++ b/facade-lib/include/facade/vk/swapchain.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <facade/util/colour_space.hpp>
 #include <facade/util/defer_queue.hpp>
 #include <facade/util/flex_array.hpp>
 #include <facade/vk/gfx.hpp>
@@ -21,6 +22,8 @@ class Swapchain {
 		std::optional<vk::PresentModeKHR> mode{};
 		std::optional<vk::Format> format{};
 	};
+
+	static constexpr ColourSpace colour_space(vk::Format format) { return is_srgb(format) ? ColourSpace::eSrgb : ColourSpace::eLinear; }
 
 	Swapchain(Gfx const& gfx, vk::UniqueSurfaceKHR surface, vk::PresentModeKHR mode);
 

--- a/facade-lib/src/editor/common.cpp
+++ b/facade-lib/src/editor/common.cpp
@@ -1,0 +1,15 @@
+#include <imgui.h>
+#include <facade/editor/common.hpp>
+
+namespace facade::editor {
+Window::Window(char const* label, bool* open_if, int flags) : m_open(ImGui::Begin(label, open_if, flags)) {}
+
+// ImGui windows requires End() even if Begin() returned false
+Window::~Window() { ImGui::End(); }
+
+TreeNode::TreeNode(char const* label, int flags) : m_open(ImGui::TreeNodeEx(label, flags)) {}
+
+TreeNode::~TreeNode() {
+	if (m_open) { ImGui::TreePop(); }
+}
+} // namespace facade::editor

--- a/facade-lib/src/editor/inspector.cpp
+++ b/facade-lib/src/editor/inspector.cpp
@@ -1,0 +1,130 @@
+#include <imgui.h>
+#include <facade/editor/inspector.hpp>
+#include <facade/scene/scene.hpp>
+#include <facade/util/string.hpp>
+#include <cassert>
+
+namespace facade::editor {
+namespace {
+bool eq(float const a, float const b, float const epsilon = 0.001f) { return std::abs(a - b) < epsilon; }
+constexpr glm::vec3 to_radian(glm::vec3 const& angles) { return {glm::radians(angles.x), glm::radians(angles.y), glm::radians(angles.z)}; }
+constexpr glm::vec3 to_degree(glm::vec3 const& angles) { return {glm::degrees(angles.x), glm::degrees(angles.y), glm::degrees(angles.z)}; }
+
+struct Modified {
+	bool value{};
+
+	constexpr bool operator()(bool const modified) {
+		value |= modified;
+		return modified;
+	}
+};
+} // namespace
+
+Inspector::Inspector(Window const& target) { assert(target.is_open()); }
+
+bool Inspector::inspect(char const* label, glm::vec2& out_vec2, float speed, float lo, float hi) const {
+	float arr[2] = {out_vec2.x, out_vec2.y};
+	ImGui::DragFloat2(label, arr, speed, lo, hi);
+	if (!eq(arr[0], out_vec2.x) || !eq(arr[1], out_vec2.y)) {
+		out_vec2 = {arr[0], arr[1]};
+		return true;
+	}
+	return false;
+}
+
+bool Inspector::inspect(char const* label, glm::vec3& out_vec3, float speed, float lo, float hi) const {
+	float arr[3] = {out_vec3.x, out_vec3.y, out_vec3.z};
+	ImGui::DragFloat3(label, arr, speed, lo, hi);
+	if (!eq(arr[0], out_vec3.x) || !eq(arr[1], out_vec3.y) || !eq(arr[2], out_vec3.z)) {
+		out_vec3 = {arr[0], arr[1], arr[2]};
+		return true;
+	}
+	return false;
+}
+
+bool Inspector::inspect(char const* label, glm::vec4& out_vec4, float speed, float lo, float hi) const {
+	float arr[4] = {out_vec4.x, out_vec4.y, out_vec4.z, out_vec4.w};
+	ImGui::DragFloat4(label, arr, speed, lo, hi);
+	if (!eq(arr[0], out_vec4.x) || !eq(arr[1], out_vec4.y) || !eq(arr[2], out_vec4.z) || !eq(arr[3], out_vec4.w)) {
+		out_vec4 = {arr[0], arr[1], arr[2], arr[3]};
+		return true;
+	}
+	return false;
+}
+
+bool Inspector::inspect(char const* label, glm::quat& out_quat) const {
+	auto euler = to_degree(glm::eulerAngles(out_quat));
+	if (inspect(label, euler, 0.5f, -180.0f, 180.0f)) {
+		out_quat = glm::quat(to_radian(euler));
+		return true;
+	}
+	return false;
+}
+
+bool Inspector::inspect(Transform& out_transform) const {
+	auto ret = Modified{};
+	if (auto tn = TreeNode{"Transform"}) {
+		auto vec3 = out_transform.position();
+		if (ret(inspect("Position", vec3))) { out_transform.set_position(vec3); }
+		auto quat = out_transform.orientation();
+		if (ret(inspect("Orientation", quat))) { out_transform.set_orientation(quat); }
+		vec3 = out_transform.scale();
+		if (ret(inspect("Scale", vec3))) { out_transform.set_scale(vec3); }
+	}
+	return ret.value;
+}
+
+SceneInspector::SceneInspector(Window const& target, Scene& scene) : Inspector(target), m_scene(scene) { assert(target.is_open()); }
+
+bool SceneInspector::inspect(TreeNode const& node, UnlitMaterial& out_material) const {
+	assert(node.is_open());
+	auto ret = Modified{};
+	ret(inspect("Tint", out_material.tint, 0.01f, 0.0f, 1.0f));
+	return ret.value;
+}
+
+bool SceneInspector::inspect(TreeNode const& node, LitMaterial& out_material) const {
+	assert(node.is_open());
+	auto ret = Modified{};
+	ret(ImGui::SliderFloat("Metallic", &out_material.metallic, 0.0f, 1.0f));
+	ret(ImGui::SliderFloat("Roughness", &out_material.roughness, 0.0f, 1.0f));
+	return ret.value;
+}
+
+bool SceneInspector::inspect(Id<Material> material_id) const {
+	auto* material = m_scene.find_material(material_id);
+	if (!material) { return false; }
+	if (auto* unlit = dynamic_cast<UnlitMaterial*>(material)) {
+		if (auto tn = TreeNode{concat("Material (Unlit) (", material_id, ")").c_str()}) { return inspect(tn, *unlit); }
+		return false;
+	} else if (auto* lit = dynamic_cast<LitMaterial*>(material)) {
+		if (auto tn = TreeNode{concat("Material (Lit) (", material_id, ")").c_str()}) { return inspect(tn, *lit); }
+		return false;
+	}
+	return false;
+}
+
+bool SceneInspector::inspect(Id<Node> node_id) const {
+	auto ret = Modified{};
+	auto* node = m_scene.find_node(node_id);
+	if (!node) { return false; }
+	ret(inspect(node->transform));
+	if (auto const* mesh_id = node->find<Id<Mesh>>()) { ret(inspect(*mesh_id)); }
+	return ret.value;
+}
+
+bool SceneInspector::inspect(Id<Mesh> mesh_id) const {
+	auto ret = Modified{};
+	auto* mesh = m_scene.find_mesh(mesh_id);
+	if (!mesh) { return ret.value; }
+	if (auto tn = TreeNode{concat("Mesh (", mesh_id, ")").c_str()})
+		for (std::size_t i = 0; i < mesh->primitives.size(); ++i) {
+			if (auto tn = TreeNode{concat("Primitive ", i).c_str()}) {
+				auto const& primitive = mesh->primitives[i];
+				ImGui::Text("%s", concat("Static Mesh: (", primitive.static_mesh, ")").c_str());
+				if (primitive.material) { ret(inspect(*primitive.material)); }
+			}
+		}
+	return ret.value;
+}
+} // namespace facade::editor

--- a/facade-lib/src/engine/renderer.cpp
+++ b/facade-lib/src/engine/renderer.cpp
@@ -38,6 +38,7 @@ struct Renderer::Impl {
 			  window,
 			  render_pass.render_pass(),
 			  info.samples,
+			  Swapchain::colour_space(swapchain.info.imageFormat),
 		  }) {}
 };
 

--- a/facade-lib/src/scene/scene.cpp
+++ b/facade-lib/src/scene/scene.cpp
@@ -241,6 +241,8 @@ Node const* Scene::find_node(Id<Node> id) const { return find_node(m_tree.roots,
 
 Material* Scene::find_material(Id<Material> id) const { return id >= m_storage.materials.size() ? nullptr : m_storage.materials[id].get(); }
 
+Mesh const* Scene::find_mesh(Id<Mesh> id) const { return id >= m_storage.meshes.size() ? nullptr : &m_storage.meshes[id]; }
+
 bool Scene::select_camera(Id<Camera> id) {
 	if (id >= camera_count()) { return false; }
 	*camera().find<Id<Camera>>() = id;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,8 @@
 #include <facade/scene/fly_cam.hpp>
 #include <facade/scene/scene.hpp>
 
+#include <facade/editor/inspector.hpp>
+
 #include <bin/shaders.hpp>
 
 using namespace facade;
@@ -184,12 +186,11 @@ void run() {
 		ImGui::ShowDemoWindow();
 
 		ImGui::SetNextWindowSize({250.0f, 100.0f}, ImGuiCond_Once);
-		if (ImGui::Begin("Material")) {
-			auto* mat = static_cast<LitMaterial*>(scene.find_material(material_id));
-			ImGui::SliderFloat("Metallic", &mat->metallic, 0.0f, 1.0f);
-			ImGui::SliderFloat("Roughness", &mat->roughness, 0.0f, 1.0f);
+		if (auto window = editor::Window{"Node"}) {
+			static auto s_input = int{};
+			ImGui::InputInt("Id", &s_input);
+			editor::SceneInspector{window, scene}.inspect(Id<Node>{static_cast<std::size_t>(s_input)});
 		}
-		ImGui::End();
 
 		engine.render(scene);
 	}


### PR DESCRIPTION
Use RAII for some common Dear ImGui `Begin()` / `End()` patterns. 
Express invariants - eg inspection of types requiring an existing Dear ImGui window - through code.
Fix Dear ImGui style colours if using an sRGB swapchain (default).
