### PR TITLE
Improve GLTF loading and Inspector

### DIFF
--- a/lib/engine/include/facade/engine/editor/common.hpp
+++ b/lib/engine/include/facade/engine/editor/common.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <facade/util/bool.hpp>
 #include <facade/util/pinned.hpp>
 #include <glm/vec2.hpp>
 #include <cassert>
@@ -14,7 +15,7 @@ class Openable : public Pinned {
 	explicit operator bool() const { return is_open(); }
 
   protected:
-	Openable(bool is_open);
+	Openable(bool is_open = false);
 	bool m_open;
 };
 
@@ -34,7 +35,7 @@ class Window : public Openable {
 	class Menu;
 
 	explicit Window(char const* label, bool* open_if = {}, int flags = {});
-	Window(NotClosed<Window> parent, char const* label, glm::vec2 size = {}, bool border = {}, int flags = {});
+	Window(NotClosed<Window> parent, char const* label, glm::vec2 size = {}, Bool border = {}, int flags = {});
 	~Window();
 
   private:
@@ -63,7 +64,7 @@ class MenuBar : public Openable {
 ///
 class Menu : public Openable {
   public:
-	explicit Menu(NotClosed<MenuBar>, char const* label, bool enabled = true);
+	explicit Menu(NotClosed<MenuBar>, char const* label, Bool enabled = {true});
 	~Menu();
 };
 
@@ -90,14 +91,14 @@ class MainMenu : public MenuBar {
 ///
 class Popup : public Openable {
   public:
-	explicit Popup(char const* id, int flags = {}) : Popup(id, false, flags) {}
+	explicit Popup(char const* id, Bool centered = {}, int flags = {}) : Popup(id, {}, centered, flags) {}
 	~Popup();
 
 	static void open(char const* id);
 	static void close_current();
 
   protected:
-	explicit Popup(char const* id, bool modal, int flags);
+	explicit Popup(char const* id, Bool modal, Bool centered, int flags);
 };
 
 ///
@@ -105,7 +106,7 @@ class Popup : public Openable {
 ///
 class Modal : public Popup {
   public:
-	explicit Modal(char const* id, int flags = {}) : Popup(id, true, flags) {}
+	explicit Modal(char const* id, Bool centered = {true}, int flags = {}) : Popup(id, {true}, centered, flags) {}
 };
 
 ///

--- a/lib/engine/src/editor/common.cpp
+++ b/lib/engine/src/editor/common.cpp
@@ -7,8 +7,8 @@ Openable::Openable(bool is_open) : m_open(is_open) {}
 
 Window::Window(char const* label, bool* open_if, int flags) : Openable(ImGui::Begin(label, open_if, flags)) {}
 
-Window::Window(NotClosed<Window>, char const* label, glm::vec2 size, bool border, int flags)
-	: Openable(ImGui::BeginChild(label, {size.x, size.y}, border, flags)), m_child(true) {}
+Window::Window(NotClosed<Window>, char const* label, glm::vec2 size, Bool border, int flags)
+	: Openable(ImGui::BeginChild(label, {size.x, size.y}, border.value, flags)), m_child(true) {}
 
 // ImGui windows requires End() even if Begin() returned false
 Window::~Window() {
@@ -37,7 +37,17 @@ MainMenu::~MainMenu() {
 	if (m_open) { ImGui::EndMainMenuBar(); }
 }
 
-Popup::Popup(char const* id, bool modal, int flags) : Openable(modal ? ImGui::BeginPopupModal(id, {}, flags) : ImGui::BeginPopup(id, flags)) {}
+Popup::Popup(char const* id, Bool modal, Bool centered, int flags) {
+	if (centered) {
+		auto const center = ImGui::GetMainViewport()->GetCenter();
+		ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2{0.5f, 0.5f});
+	}
+	if (modal) {
+		m_open = ImGui::BeginPopupModal(id, {}, flags);
+	} else {
+		m_open = ImGui::BeginPopup(id, flags);
+	}
+}
 
 Popup::~Popup() {
 	if (m_open) { ImGui::EndPopup(); }
@@ -47,7 +57,7 @@ void Popup::open(char const* id) { ImGui::OpenPopup(id); }
 
 void Popup::close_current() { ImGui::CloseCurrentPopup(); }
 
-Menu::Menu(NotClosed<MenuBar>, char const* label, bool enabled) : Openable(ImGui::BeginMenu(label, enabled)) {}
+Menu::Menu(NotClosed<MenuBar>, char const* label, Bool enabled) : Openable(ImGui::BeginMenu(label, enabled.value)) {}
 
 Menu::~Menu() {
 	if (m_open) { ImGui::EndMenu(); }

--- a/lib/util/CMakeLists.txt
+++ b/lib/util/CMakeLists.txt
@@ -64,6 +64,7 @@ target_compile_definitions(${PROJECT_NAME}
 
 target_sources(${PROJECT_NAME} PRIVATE
   include/${target_prefix}/util/async_queue.hpp
+  include/${target_prefix}/util/bool.hpp
   include/${target_prefix}/util/byte_buffer.hpp
   include/${target_prefix}/util/colour_space.hpp
   include/${target_prefix}/util/data_provider.hpp

--- a/lib/util/include/facade/util/bool.hpp
+++ b/lib/util/include/facade/util/bool.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <cstdint>
+
+namespace facade {
+///
+/// \brief Strongly typed alias for booleans (no implicit conversions)
+///
+struct Bool {
+	bool value{};
+
+	explicit constexpr operator bool() const { return value; }
+};
+} // namespace facade

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -294,11 +294,11 @@ void run() {
 
 		if (loading.status > LoadStatus::eNone) {
 			auto const* main_viewport = ImGui::GetMainViewport();
-			ImGui::SetNextWindowPos({0.0f, main_viewport->WorkPos.y + main_viewport->Size.y - 75.0f});
-			ImGui::SetNextWindowSize({-1.0f, 75.0f});
-			auto window = editor::Window{loading.title.c_str(), nullptr, ImGuiWindowFlags_NoTitleBar};
+			ImGui::SetNextWindowPos({0.0f, main_viewport->WorkPos.y + main_viewport->Size.y - 100.0f});
+			ImGui::SetNextWindowSize({main_viewport->Size.x, 100.0f});
+			auto window = editor::Window{loading.title.c_str(), nullptr, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize};
 			ImGui::Text("%s", load_status_str[loading.status].data());
-			ImGui::ProgressBar(load_progress(loading.status), ImVec2{main_viewport->WorkSize.x, 0.0f}, load_status_str[loading.status].data());
+			ImGui::ProgressBar(load_progress(loading.status), ImVec2{-1.0f, 0.0f}, load_status_str[loading.status].data());
 		}
 
 		auto& camera = engine->scene().camera();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 
 #include <bin/shaders.hpp>
 
+#include <filesystem>
 #include <iostream>
 
 #include <imgui.h>
@@ -26,6 +27,8 @@
 using namespace facade;
 
 namespace {
+namespace fs = std::filesystem;
+
 static constexpr auto test_json_v = R"(
 {
   "scene": 0,
@@ -206,6 +209,16 @@ void log_prologue() {
 	logger::info("facade v{}.{}.{} | {} |", 0, 0, 0, buf);
 }
 
+fs::path find_gltf(fs::path root) {
+	if (root.extension() == ".gltf") { return root; }
+	for (auto const& it : fs::directory_iterator{root}) {
+		if (!it.is_regular_file()) { continue; }
+		auto path = it.path();
+		if (path.extension() == ".gltf") { return path; }
+	}
+	return {};
+}
+
 void run() {
 	auto engine = std::optional<Engine>{};
 
@@ -267,17 +280,25 @@ void run() {
 		if (input.keyboard.pressed(GLFW_KEY_ESCAPE)) { engine->request_stop(); }
 		glfwSetInputMode(engine->window(), GLFW_CURSOR, mouse_look ? GLFW_CURSOR_DISABLED : GLFW_CURSOR_NORMAL);
 
-		if (!state.file_drops.empty()) {
-			engine->load_async(state.file_drops.front(), [&] { post_scene_load(engine->scene()); });
-			loading.title = fmt::format("Loading {}...", state.to_filename(state.file_drops.front()));
-			editor::Popup::open(loading.title.c_str());
+		if (!state.file_drops.empty() && engine->load_status() == LoadStatus::eNone) {
+			auto path = find_gltf(state.file_drops.front());
+			if (!fs::is_regular_file(path)) {
+				logger::error("Failed to locate .gltf in path: [{}]", state.file_drops.front());
+			} else {
+				if (engine->load_async(path.generic_string(), [&] { post_scene_load(engine->scene()); })) {
+					loading.title = fmt::format("Loading {}...", path.filename().generic_string());
+				}
+			}
 		}
 		loading.status = engine->load_status();
 
-		if (auto popup = editor::Modal{loading.title.c_str()}) {
+		if (loading.status > LoadStatus::eNone) {
+			auto const* main_viewport = ImGui::GetMainViewport();
+			ImGui::SetNextWindowPos({0.0f, main_viewport->WorkPos.y + main_viewport->Size.y - 75.0f});
+			ImGui::SetNextWindowSize({-1.0f, 75.0f});
+			auto window = editor::Window{loading.title.c_str(), nullptr, ImGuiWindowFlags_NoTitleBar};
 			ImGui::Text("%s", load_status_str[loading.status].data());
-			ImGui::ProgressBar(load_progress(loading.status), ImVec2{400.0f, 0}, load_status_str[loading.status].data());
-			if (loading.status == LoadStatus::eNone) { editor::Popup::close_current(); }
+			ImGui::ProgressBar(load_progress(loading.status), ImVec2{main_viewport->WorkSize.x, 0.0f}, load_status_str[loading.status].data());
 		}
 
 		auto& camera = engine->scene().camera();


### PR DESCRIPTION
- If directory dragged onto window, search for `.gltf` in it.
- Improve progres bar: use full-width window at bottom instead of a modal popup.
- Add and use `struct Bool` as conversion-resistant alias for `bool`.
- Use `ImGui::CollapsingHeader` for Inspector root nodes.
- Separate visual label and ID for named / numbered scene components.
- Open `Transform` by default in inspector.

![Screenshot_20221029_150948](https://user-images.githubusercontent.com/16272243/198854191-75618671-f5f7-479a-b403-75c6e2c93e55.png)

