### PR TITLE
Refactor MainMenu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,9 @@ if(FACADE_BUILD_EXE)
   add_executable(${PROJECT_NAME})
 
   target_sources(${PROJECT_NAME} PRIVATE
+    src/main_menu/main_menu.cpp
+    src/main_menu/main_menu.hpp
+
     src/main.cpp
 
     src/bin/shaders.cpp

--- a/lib/engine/include/facade/engine/editor/common.hpp
+++ b/lib/engine/include/facade/engine/editor/common.hpp
@@ -4,6 +4,11 @@
 #include <glm/vec2.hpp>
 #include <cassert>
 #include <concepts>
+#include <span>
+
+namespace facade {
+class Engine;
+}
 
 namespace facade::editor {
 ///
@@ -25,6 +30,9 @@ class Openable : public Pinned {
 template <typename T>
 struct NotClosed {
 	NotClosed([[maybe_unused]] T const& t) { assert(t.is_open()); }
+
+	template <std::derived_from<T> Derived>
+	NotClosed(NotClosed<Derived>) {}
 };
 
 ///

--- a/lib/engine/include/facade/engine/editor/log.hpp
+++ b/lib/engine/include/facade/engine/editor/log.hpp
@@ -5,16 +5,13 @@
 #include <vector>
 
 namespace facade::editor {
-class Log : public logger::Accessor {
-  public:
-	void render(NotClosed<Window> window);
+struct LogState {
+	EnumArray<logger::Level, bool> level_filter{true, true, true, debug_v};
+	int display_count{50};
+	bool auto_scroll{true};
 
-  private:
-	void operator()(std::span<logger::Entry const> entries) final;
-
-	std::vector<logger::Entry const*> m_list{};
-	EnumArray<logger::Level, bool> m_level_filter{true, true, true, debug_v};
-	int m_display_count{50};
-	bool m_auto_scroll{true};
+	std::vector<logger::Entry const*> list{};
 };
+
+void display_log(NotClosed<Window> window, LogState& out_state);
 } // namespace facade::editor

--- a/lib/engine/src/editor/inspector.cpp
+++ b/lib/engine/src/editor/inspector.cpp
@@ -110,7 +110,6 @@ bool Inspector::inspect(std::span<Transform> out_instances, Bool unified_scaling
 }
 
 bool Inspector::inspect(Lights& out_lights) const {
-	if (out_lights.dir_lights.empty()) { return false; }
 	auto ret = Modified{};
 	auto to_remove = std::optional<std::size_t>{};
 	bool allow_removal = out_lights.dir_lights.size() > 1;

--- a/lib/engine/src/editor/log.cpp
+++ b/lib/engine/src/editor/log.cpp
@@ -3,31 +3,30 @@
 #include <facade/engine/editor/log.hpp>
 #include <facade/util/fixed_string.hpp>
 
-namespace facade::editor {
-void Log::render(NotClosed<Window> window) {
-	ImGui::Text("%s", FixedString{"Count: {}", m_display_count}.c_str());
+namespace facade {
+void editor::display_log(NotClosed<Window> window, LogState& out_state) {
+	ImGui::Text("%s", FixedString{"Count: {}", out_state.display_count}.c_str());
 	ImGui::SameLine();
 	float spacing = ImGui::GetStyle().ItemInnerSpacing.x;
 	ImGui::PushButtonRepeat(true);
 	auto const max_logs = static_cast<int>(logger::buffer_size().total());
-	if (ImGui::ArrowButton("##left", ImGuiDir_Left)) { m_display_count = std::clamp(m_display_count - 10, 0, max_logs); }
+	if (ImGui::ArrowButton("##left", ImGuiDir_Left)) { out_state.display_count = std::clamp(out_state.display_count - 10, 0, max_logs); }
 	ImGui::SameLine(0.0f, spacing);
-	if (ImGui::ArrowButton("##right", ImGuiDir_Right)) { m_display_count = std::clamp(m_display_count + 10, 0, max_logs); }
+	if (ImGui::ArrowButton("##right", ImGuiDir_Right)) { out_state.display_count = std::clamp(out_state.display_count + 10, 0, max_logs); }
 	ImGui::PopButtonRepeat();
 
 	static constexpr std::string_view levels_v[] = {"Error", "Warn", "Info", "Debug"};
 	static constexpr auto max_log_level_v = debug_v ? logger::Level::eDebug : logger::Level::eInfo;
 	for (logger::Level l = logger::Level::eError; l <= max_log_level_v; l = static_cast<logger::Level>(static_cast<int>(l) + 1)) {
 		ImGui::SameLine();
-		ImGui::Checkbox(levels_v[static_cast<std::size_t>(l)].data(), &m_level_filter[l]);
+		ImGui::Checkbox(levels_v[static_cast<std::size_t>(l)].data(), &out_state.level_filter[l]);
 	}
 	ImGui::SameLine();
 	ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
 	ImGui::SameLine();
-	ImGui::Checkbox("Auto-scroll", &m_auto_scroll);
+	ImGui::Checkbox("Auto-scroll", &out_state.auto_scroll);
 
 	ImGui::Separator();
-	logger::access_buffer(*this);
 	auto child = editor::Window{window, "scroll", {}, {}, ImGuiWindowFlags_HorizontalScrollbar};
 	static constexpr auto im_colour = [](logger::Level const l) {
 		switch (l) {
@@ -38,21 +37,13 @@ void Log::render(NotClosed<Window> window) {
 		case logger::Level::eDebug: return ImVec4{0.5f, 0.5f, 0.5f, 1.0f};
 		}
 	};
-	auto span = std::span{m_list};
-	auto const max_size = static_cast<std::size_t>(m_display_count);
+	auto span = std::span{out_state.list};
+	auto const max_size = static_cast<std::size_t>(out_state.display_count);
 	if (span.size() > max_size) { span = span.subspan(span.size() - max_size); }
 	if (auto style = editor::StyleVar{ImGuiStyleVar_ItemSpacing, glm::vec2{}}) {
 		for (auto const* entry : span) ImGui::TextColored(im_colour(entry->level), "%s", entry->message.c_str());
 	}
 
-	if (m_auto_scroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) { ImGui::SetScrollHereY(1.0f); }
+	if (out_state.auto_scroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY()) { ImGui::SetScrollHereY(1.0f); }
 }
-
-void Log::operator()(std::span<logger::Entry const> entries) {
-	m_list.clear();
-	for (auto const& entry : entries) {
-		if (!m_level_filter[entry.level]) { continue; }
-		m_list.push_back(&entry);
-	}
-}
-} // namespace facade::editor
+} // namespace facade

--- a/src/main_menu/main_menu.cpp
+++ b/src/main_menu/main_menu.cpp
@@ -1,0 +1,143 @@
+#include <imgui.h>
+#include <facade/engine/editor/inspector.hpp>
+#include <facade/engine/editor/scene_tree.hpp>
+#include <facade/engine/engine.hpp>
+#include <facade/render/renderer.hpp>
+#include <facade/util/error.hpp>
+#include <facade/util/fixed_string.hpp>
+#include <facade/util/logger.hpp>
+#include <main_menu/main_menu.hpp>
+
+namespace facade {
+void WindowMenu::display_menu(editor::NotClosed<editor::MainMenu> main) {
+	auto menu = editor::Menu{main, "Window"};
+	if (!menu) { return; }
+
+	if (ImGui::MenuItem("Scene")) { m_flags.scene = true; }
+	if (ImGui::MenuItem("Frame Stats")) { m_flags.stats = true; }
+	if (ImGui::MenuItem("Log")) { m_flags.log = true; }
+	if (ImGui::MenuItem("Close All")) { m_flags = {}; }
+	ImGui::Separator();
+	if (ImGui::MenuItem("Dear ImGui Demo")) { m_flags.demo = true; }
+}
+
+void WindowMenu::display_windows(Engine& engine) {
+	if (m_flags.scene) { m_flags.scene = display_scene(engine.scene()); }
+	if (m_flags.lights) { m_flags.lights = display_lights(engine.scene().lights); }
+	if (m_data.inspect && !display_inspector(engine.scene())) { m_data.inspect = {}; }
+	if (m_flags.log) { m_flags.log = display_log(); }
+	if (m_flags.stats) { m_flags.stats = display_stats(engine); }
+}
+
+bool WindowMenu::display_scene(Scene& scene) {
+	ImGui::SetNextWindowSize({250.0f, 350.0f}, ImGuiCond_FirstUseEver);
+	bool show{true};
+	if (auto window = editor::Window{"Scene", &show}) {
+		if (ImGui::Button("Lights")) { m_flags.lights = true; }
+		ImGui::Separator();
+		editor::SceneTree{scene}.render(window, m_data.inspect);
+	}
+	return show;
+}
+
+bool WindowMenu::display_lights(Lights& lights) {
+	ImGui::SetNextWindowSize({400.0f, 400.0f}, ImGuiCond_FirstUseEver);
+	bool show{true};
+	if (auto window = editor::Window{"Lights", &show}) { editor::Inspector{window}.inspect(lights); }
+	return show;
+}
+
+bool WindowMenu::display_inspector(Scene& scene) {
+	bool show = true;
+	ImGui::SetNextWindowSize({400.0f, 400.0f}, ImGuiCond_FirstUseEver);
+	if (auto window = editor::Window{m_data.inspect.name.c_str(), &show}) {
+		editor::SceneInspector{window, scene}.inspect(m_data.inspect.id, m_data.unified_scaling);
+	}
+	return m_data.inspect && show;
+}
+
+bool WindowMenu::display_stats(Engine& engine) {
+	ImGui::SetNextWindowSize({250.0f, 200.0f}, ImGuiCond_FirstUseEver);
+	bool show{true};
+	if (auto window = editor::Window{"Frame Stats", &show}) {
+		auto const& stats = engine.renderer().frame_stats();
+		ImGui::Text("%s", FixedString{"Counter: {}", stats.frame_counter}.c_str());
+		ImGui::Text("%s", FixedString{"Triangles: {}", stats.triangles}.c_str());
+		ImGui::Text("%s", FixedString{"Draw calls: {}", stats.draw_calls}.c_str());
+		ImGui::Text("%s", FixedString{"FPS: {}", (stats.fps == 0 ? static_cast<std::uint32_t>(stats.frame_counter) : stats.fps)}.c_str());
+		ImGui::Text("%s", FixedString{"Frame time: {:.2f}ms", engine.state().dt * 1000.0f}.c_str());
+		ImGui::Text("%s", FixedString{"GPU: {}", stats.gpu_name}.c_str());
+		ImGui::Text("%s", FixedString{"MSAA: {}x", to_int(stats.msaa)}.c_str());
+		if (ImGui::SmallButton("Vsync")) { change_vsync(engine); }
+		ImGui::SameLine();
+		ImGui::Text("%s", vsync_status(stats.mode).data());
+	}
+	return show;
+}
+
+bool WindowMenu::display_log() {
+	bool show{true};
+	ImGui::SetNextWindowSize({600.0f, 200.0f}, ImGuiCond_FirstUseEver);
+	if (auto window = editor::Window{"Log", &show}) {
+		logger::access_buffer(*this);
+		editor::display_log(window, m_data.log_state);
+	}
+	return show;
+}
+
+void WindowMenu::change_vsync(Engine const& engine) const {
+	static constexpr vk::PresentModeKHR modes[] = {vk::PresentModeKHR::eFifo, vk::PresentModeKHR::eFifoRelaxed, vk::PresentModeKHR::eMailbox,
+												   vk::PresentModeKHR::eImmediate};
+	static std::size_t index{0};
+	auto const next_mode = [&] {
+		while (true) {
+			index = (index + 1) % std::size(modes);
+			auto const ret = modes[index];
+			if (!engine.renderer().is_supported(ret)) { continue; }
+			return ret;
+		}
+		throw Error{"Invariant violated"};
+	}();
+	engine.renderer().request_mode(next_mode);
+	logger::info("Requesting present mode: [{}]", present_mode_str(next_mode));
+}
+
+void WindowMenu::operator()(std::span<logger::Entry const> entries) {
+	m_data.log_state.list.clear();
+	for (auto const& entry : entries) {
+		if (!m_data.log_state.level_filter[entry.level]) { continue; }
+		m_data.log_state.list.push_back(&entry);
+	}
+}
+
+void FileMenu::add_recent(std::string path) {
+	if (auto it = std::find(m_recents.begin(), m_recents.end(), path); it != m_recents.end()) { m_recents.erase(it); }
+	m_recents.push_back(std::move(path));
+	max_recents = std::max(max_recents, std::uint8_t{1});
+	auto const trim = static_cast<std::ptrdiff_t>(m_recents.size()) - static_cast<std::ptrdiff_t>(max_recents);
+	if (trim > 0) {
+		std::rotate(m_recents.begin(), m_recents.begin() + trim, m_recents.end());
+		m_recents.erase(m_recents.begin() + static_cast<std::ptrdiff_t>(max_recents), m_recents.end());
+	}
+}
+
+auto FileMenu::display(editor::NotClosed<editor::MainMenu> main) -> Command {
+	auto ret = Command{};
+	if (auto file = editor::Menu{main, "File"}) {
+		if (!m_recents.empty()) { ret = open_recent(main); }
+		ImGui::Separator();
+		if (ImGui::MenuItem("Exit")) { ret = Shutdown{}; }
+	}
+	return ret;
+}
+
+auto FileMenu::open_recent(editor::NotClosed<editor::MainMenu> main) -> Command {
+	auto ret = Command{};
+	if (auto open_recent = editor::Menu{main, "Open Recent"}) {
+		for (auto it = m_recents.rbegin(); it != m_recents.rend(); ++it) {
+			if (ImGui::MenuItem(Engine::State::to_filename(*it).c_str())) { ret = OpenRecent{.path = *it}; }
+		}
+	}
+	return ret;
+}
+} // namespace facade

--- a/src/main_menu/main_menu.hpp
+++ b/src/main_menu/main_menu.hpp
@@ -1,0 +1,61 @@
+#pragma once
+#include <facade/engine/editor/common.hpp>
+#include <facade/engine/editor/log.hpp>
+#include <facade/engine/editor/scene_tree.hpp>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace facade {
+struct Lights;
+
+class FileMenu {
+  public:
+	struct OpenRecent {
+		std::string path{};
+	};
+	struct Shutdown {};
+	using Command = std::variant<std::monostate, OpenRecent, Shutdown>;
+
+	void add_recent(std::string path);
+	Command display(editor::NotClosed<editor::MainMenu> main);
+
+	std::uint8_t max_recents{8};
+
+  private:
+	Command open_recent(editor::NotClosed<editor::MainMenu> main);
+
+	std::vector<std::string> m_recents;
+};
+
+class WindowMenu : public logger::Accessor {
+  public:
+	void display_menu(editor::NotClosed<editor::MainMenu> main);
+	void display_windows(Engine& engine);
+
+  private:
+	bool display_scene(Scene& scene);
+	bool display_inspector(Scene& scene);
+	bool display_lights(Lights& lights);
+	bool display_stats(Engine& engine);
+	bool display_log();
+
+	void change_vsync(Engine const& engine) const;
+
+	void operator()(std::span<logger::Entry const> entries) final;
+
+	struct {
+		editor::LogState log_state{};
+		editor::InspectNode inspect{};
+		Bool unified_scaling{true};
+	} m_data{};
+	struct {
+		bool scene{};
+		bool lights{};
+		bool stats{};
+		bool log{};
+		bool close{};
+		bool demo{};
+	} m_flags{};
+};
+} // namespace facade


### PR DESCRIPTION
- Create `main_menu/main_menu.[hc]cpp`
- Remove `editor::Log`, move state storage into `WindowMenu`
- Have `FileMenu` return a `Command` instead of executing (incomplete) logic itself
