### PR TITLE
Refactor SceneResources

### DIFF
--- a/lib/engine/CMakeLists.txt
+++ b/lib/engine/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(${PROJECT_NAME} PRIVATE
   include/${target_prefix}/engine/editor/browse_file.hpp
   include/${target_prefix}/engine/editor/common.hpp
   include/${target_prefix}/engine/editor/drag_drop_id.hpp
+  include/${target_prefix}/engine/editor/inspect_data.hpp
   include/${target_prefix}/engine/editor/inspector.hpp
   include/${target_prefix}/engine/editor/log.hpp
   include/${target_prefix}/engine/editor/reflector.hpp

--- a/lib/engine/include/facade/engine/editor/inspect_data.hpp
+++ b/lib/engine/include/facade/engine/editor/inspect_data.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <string>
+
+namespace facade::editor {
+struct InspectData {
+	std::string input_buffer{};
+	int material_type{};
+};
+} // namespace facade::editor

--- a/lib/engine/include/facade/engine/editor/inspector.hpp
+++ b/lib/engine/include/facade/engine/editor/inspector.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <facade/engine/editor/common.hpp>
+#include <facade/engine/editor/inspect_data.hpp>
 #include <facade/scene/scene.hpp>
 
 namespace facade::editor {
@@ -20,7 +21,7 @@ class Inspector {
 
 	NotClosed<Window> m_target;
 	Scene& m_scene;
-	SceneResourcesMut m_resources;
+	SceneResources& m_resources;
 };
 
 ///
@@ -67,15 +68,17 @@ class ResourceInspector : public Inspector {
 ///
 class SceneInspector : public Inspector {
   public:
+	using Data = InspectData;
+
 	SceneInspector(NotClosed<Window> target, Scene& out_scene) : Inspector(target, out_scene) {}
 
 	///
 	/// \brief View/edit all resources.
-	/// \param out_name_buf Persistent buffer for popups
+	/// \param out_data Persistent data for popups
 	///
 	/// Uses ResourceInspector.
 	///
-	void resources(std::string& out_name_buf) const;
+	void resources(Data& out_data) const;
 	///
 	/// \brief Inspect the Scene's camera.
 	///

--- a/lib/engine/src/scene_renderer.cpp
+++ b/lib/engine/src/scene_renderer.cpp
@@ -90,17 +90,17 @@ std::span<glm::mat4x4 const> SceneRenderer::make_instances(Node const& node, glm
 }
 
 void SceneRenderer::render(Renderer& renderer, vk::CommandBuffer cb, Node const& node, glm::mat4 const& parent) {
-	auto const resources = m_scene->resources();
+	auto const& resources = m_scene->resources();
 	if (auto const* mesh_id = node.find<Id<Mesh>>()) {
-		static auto const s_default_material = LitMaterial{};
+		static auto const s_default_material = Material{std::make_unique<LitMaterial>()};
 		auto const& mesh = resources.meshes[*mesh_id];
 		for (auto const& primitive : mesh.primitives) {
-			auto const& material = primitive.material ? *resources.materials[primitive.material->value()] : static_cast<Material const&>(s_default_material);
+			auto const& material = primitive.material ? resources.materials[primitive.material->value()] : static_cast<Material const&>(s_default_material);
 			auto pipeline = renderer.bind_pipeline(cb, m_scene->pipeline_state, material.shader_id());
 			pipeline.set_line_width(m_scene->pipeline_state.line_width);
 
 			update_view(pipeline);
-			auto const store = TextureStore{resources.textures, m_white, m_black};
+			auto const store = TextureStore{resources.textures.view(), m_white, m_black};
 			material.write_sets(pipeline, store);
 
 			auto const& static_mesh = resources.static_meshes[primitive.static_mesh];

--- a/lib/scene/CMakeLists.txt
+++ b/lib/scene/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(${PROJECT_NAME} PRIVATE
   include/${target_prefix}/scene/mesh.hpp
   include/${target_prefix}/scene/node_data.hpp
   include/${target_prefix}/scene/node.hpp
+  include/${target_prefix}/scene/resource_array.hpp
   include/${target_prefix}/scene/scene_resources.hpp
   include/${target_prefix}/scene/scene.hpp
 

--- a/lib/scene/include/facade/scene/material.hpp
+++ b/lib/scene/include/facade/scene/material.hpp
@@ -39,12 +39,12 @@ struct TextureStore {
 };
 
 ///
-/// \brief Base Material: stores render parameters for a mesh.
+/// \brief Base class for concrete materials.
 ///
 class MaterialBase {
   public:
 	///
-	/// \brief The alpha blend mode.
+	/// \brief Alpha blend mode.
 	///
 	enum class AlphaMode : std::uint32_t { eOpaque = 0, eBlend, eMask };
 
@@ -64,9 +64,15 @@ class MaterialBase {
 	///
 	virtual void write_sets(Pipeline& pipeline, TextureStore const& store) const = 0;
 
+	///
+	/// \brief Name of this instance.
+	///
 	std::string name{"(Unnamed)"};
 };
 
+///
+/// \brief Value-semantic strategy wrapper for concrete materials.
+///
 class Material {
   public:
 	using AlphaMode = MaterialBase::AlphaMode;

--- a/lib/scene/include/facade/scene/material.hpp
+++ b/lib/scene/include/facade/scene/material.hpp
@@ -41,25 +41,16 @@ struct TextureStore {
 ///
 /// \brief Base Material: stores render parameters for a mesh.
 ///
-class Material {
+class MaterialBase {
   public:
 	///
 	/// \brief The alpha blend mode.
 	///
 	enum class AlphaMode : std::uint32_t { eOpaque = 0, eBlend, eMask };
 
-	///
-	/// \brief Convert sRGB encoded colour to linear.
-	///
-	static glm::vec4 to_linear(glm::vec4 const& srgb);
-	///
-	/// \brief Convert linear encoded colour to sRGB.
-	///
-	static glm::vec4 to_srgb(glm::vec4 const& linear);
-
 	inline static std::string const default_shader_id{"default"};
 
-	virtual ~Material() = default;
+	virtual ~MaterialBase() = default;
 
 	///
 	/// \brief Obtain the ID for the shader used by this material.
@@ -76,10 +67,37 @@ class Material {
 	std::string name{"(Unnamed)"};
 };
 
+class Material {
+  public:
+	using AlphaMode = MaterialBase::AlphaMode;
+
+	Material(std::unique_ptr<MaterialBase>&& base) : m_base(std::move(base)) {}
+
+	std::string const& shader_id() const {
+		assert(m_base);
+		return m_base->shader_id();
+	}
+
+	void write_sets(Pipeline& pipeline, TextureStore const& store) const {
+		assert(m_base);
+		m_base->write_sets(pipeline, store);
+	}
+
+	std::string_view name() const { return m_base->name; }
+
+	MaterialBase& base() const {
+		assert(m_base);
+		return *m_base;
+	}
+
+  private:
+	std::unique_ptr<MaterialBase> m_base;
+};
+
 ///
 /// \brief Unlit Material.
 ///
-class UnlitMaterial : public Material {
+class UnlitMaterial : public MaterialBase {
   public:
 	inline static std::string const shader_id_v{"unlit"};
 
@@ -99,7 +117,7 @@ class UnlitMaterial : public Material {
 ///
 /// \brief PBR lit material.
 ///
-class LitMaterial : public Material {
+class LitMaterial : public MaterialBase {
   public:
 	///
 	/// \brief Base colour factor.

--- a/lib/scene/include/facade/scene/resource_array.hpp
+++ b/lib/scene/include/facade/scene/resource_array.hpp
@@ -1,0 +1,82 @@
+#pragma once
+#include <facade/scene/id.hpp>
+#include <facade/util/ptr.hpp>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace facade {
+///
+/// \brief Wrapper over an array of resources, each identified by the index as its Id.
+///
+/// Only Scene has access to the underlying vector (via friend). Other types can operate
+/// on const / non-const spans, but cannot modify the array itself.
+///
+template <typename T>
+class ResourceArray {
+  public:
+	///
+	/// \brief Obtain an immutable view into the underlying array.
+	/// \returns Immutable span
+	///
+	std::span<T const> view() const { return m_array; }
+	///
+	/// \brief Obtain a mutable view into the underlying array.
+	/// \returns Mutable span
+	///
+	std::span<T> view() { return m_array; }
+
+	///
+	/// \brief Obtain an immutable pointer to the element at index id.
+	/// \param id Id (index) of element
+	/// \returns nullptr if id is out of bounds
+	///
+	Ptr<T const> find(Id<T> id) const {
+		if (id >= m_array.size()) { return {}; }
+		return &m_array[id];
+	}
+
+	///
+	/// \brief Obtain a mutable pointer to the element at index id.
+	/// \param id Id (index) of element
+	/// \returns nullptr if id is out of bounds
+	///
+	Ptr<T> find(Id<T> index) { return const_cast<Ptr<T>>(std::as_const(*this).find(index)); }
+
+	///
+	/// \brief Obtain an immutable reference to the element at index id.
+	/// \param id Id (index) of element
+	/// \returns const reference to element
+	///
+	/// id must be valid / in range
+	///
+	T const& operator[](Id<T> id) const {
+		auto ret = find(id);
+		assert(ret);
+		return *ret;
+	}
+
+	///
+	/// \brief Obtain an immutable reference to the element at index id.
+	/// \param id Id (index) of element
+	/// \returns const reference to element
+	///
+	/// id must be valid / in range
+	///
+	T& operator[](Id<T> index) { return const_cast<T&>(std::as_const(*this).operator[](index)); }
+
+	///
+	/// \brief Obtain the size of the underlying array.
+	///
+	constexpr std::size_t size() const { return m_array.size(); }
+	///
+	/// \brief Check if the underlying array is empty.
+	///
+	constexpr bool empty() const { return m_array.empty(); }
+
+  private:
+	std::vector<T> m_array{};
+
+	friend class Scene;
+};
+} // namespace facade

--- a/lib/scene/include/facade/scene/scene.hpp
+++ b/lib/scene/include/facade/scene/scene.hpp
@@ -24,7 +24,6 @@ struct DataProvider;
 class Scene {
   public:
 	using Resources = SceneResources;
-	using ResourcesMut = SceneResourcesMut;
 
 	// defined in loader.hpp
 	class GltfLoader;
@@ -66,7 +65,7 @@ class Scene {
 	/// \param material Concrete Material instance to add
 	/// \returns Id to stored Material
 	///
-	Id<Material> add(std::unique_ptr<Material> material);
+	Id<Material> add(Material material);
 	///
 	/// \brief Add a StaticMesh.
 	/// \param geometry Geometry to initialize StaticMesh with
@@ -93,6 +92,23 @@ class Scene {
 	/// \returns Id to stored Node
 	///
 	Id<Node> add(Node node, Id<Node> parent);
+
+	///
+	/// \brief Replace all textures in resources.
+	/// \param textures Texture instances to swap in
+	/// \returns Previously stored textures
+	///
+	/// Intended for loaders.
+	///
+	std::vector<Texture> replace(std::vector<Texture>&& textures);
+	///
+	/// \brief Replace all static meshes in resources.
+	/// \param static_meshes StaticMesh instances to swap in
+	/// \returns Previously stored static meshes
+	///
+	/// Intended for loaders.
+	///
+	std::vector<StaticMesh> replace(std::vector<StaticMesh>&& static_meshes);
 
 	///
 	/// \brief Obtain the current Tree Id.
@@ -124,37 +140,6 @@ class Scene {
 	///
 	Ptr<Node> find(Id<Node> id);
 	///
-	/// \brief Obtain a mutable pointer to the Material corresponding to its Id.
-	/// \param id Id of the Material
-	/// \returns nullptr if id is invalid (out of bounds)
-	///
-	Ptr<Material> find(Id<Material> id) const;
-	///
-	/// \brief Obtain an immutable pointer to the StaticMesh corresponding to its Id.
-	/// \param id Id of the StaticMesh
-	/// \returns nullptr if id is invalid (out of bounds)
-	///
-	Ptr<StaticMesh const> find(Id<StaticMesh> id) const;
-	///
-	/// \brief Obtain an immutable pointer to the Texture corresponding to its Id.
-	/// \param id Id of the Texture
-	/// \returns nullptr if id is invalid (out of bounds)
-	///
-	Ptr<Texture const> find(Id<Texture> id) const;
-	///
-	/// \brief Obtain a mutable pointer to the Mesh corresponding to its Id.
-	/// \param id Id of the Mesh
-	/// \returns nullptr if id is invalid (out of bounds)
-	///
-	Ptr<Mesh> find(Id<Mesh> id);
-	///
-	/// \brief Obtain a mutable pointer to the Camera corresponding to its Id.
-	/// \param id Id of the Camera
-	/// \returns nullptr if id is invalid (out of bounds)
-	///
-	Ptr<Camera> find(Id<Camera> id);
-
-	///
 	/// \brief Obtain a mutable view into all the root nodes attached to the active Tree.
 	/// \returns Mutable view into the root nodes attached to the active Tree
 	///
@@ -169,7 +154,7 @@ class Scene {
 	/// \brief Obtain the total count of stored cameras.
 	/// \returns Count of stored cameras (at least 1)
 	///
-	std::size_t camera_count() const { return m_storage.cameras.size(); }
+	std::size_t camera_count() const { return m_storage.resources.cameras.size(); }
 	///
 	/// \brief Select a Camera by its Id.
 	/// \param id Id of Camera to select
@@ -198,11 +183,15 @@ class Scene {
 	Texture make_texture(Image::View image) const;
 
 	///
-	/// \brief Obtain a view into the stored resources.
-	/// \returns A Resources object
+	/// \brief Obtain a mutable reference to the scene's resources.
+	/// \returns Mutable reference to SceneResources
 	///
-	ResourcesMut resources() { return m_storage.resources(); }
-	Resources resources() const { return m_storage.resources(); }
+	Resources& resources() { return m_storage.resources; }
+	///
+	/// \brief Obtain an immutable reference to the scene's resources.
+	/// \returns Immutable reference to SceneResources
+	///
+	Resources const& resources() const { return m_storage.resources; }
 
 	///
 	/// \brief All the lights in the scene.
@@ -233,17 +222,8 @@ class Scene {
 	};
 
 	struct Storage {
-		std::vector<Camera> cameras{};
-		std::vector<Sampler> samplers{};
-		std::vector<std::unique_ptr<Material>> materials{};
-		std::vector<StaticMesh> static_meshes{};
-		std::vector<Texture> textures{};
-		std::vector<Mesh> meshes{};
-
+		Resources resources{};
 		Data data{};
-
-		ResourcesMut resources() { return {cameras, samplers, materials, static_meshes, textures, meshes}; }
-		Resources resources() const { return {cameras, samplers, materials, static_meshes, textures, meshes}; }
 	};
 
 	void add_default_camera();

--- a/lib/scene/include/facade/scene/scene_resources.hpp
+++ b/lib/scene/include/facade/scene/scene_resources.hpp
@@ -2,42 +2,14 @@
 #include <facade/scene/camera.hpp>
 #include <facade/scene/material.hpp>
 #include <facade/scene/mesh.hpp>
-#include <facade/util/ptr.hpp>
+#include <facade/scene/resource_array.hpp>
 #include <facade/vk/static_mesh.hpp>
 #include <facade/vk/texture.hpp>
-#include <span>
 
 namespace facade {
-template <typename T>
-class ResourceArray {
-  public:
-	std::span<T> view() { return m_array; }
-	std::span<T const> view() const { return m_array; }
-
-	Ptr<T const> find(Id<T> index) const {
-		if (index >= m_array.size()) { return {}; }
-		return &m_array[index];
-	}
-
-	Ptr<T> find(Id<T> index) { return const_cast<Ptr<T>>(std::as_const(*this).find(index)); }
-
-	T const& operator[](Id<T> index) const {
-		auto ret = find(index);
-		assert(ret);
-		return *ret;
-	}
-
-	T& operator[](Id<T> index) { return const_cast<T&>(std::as_const(*this).operator[](index)); }
-
-	constexpr std::size_t size() const { return m_array.size(); }
-	constexpr bool empty() const { return m_array.empty(); }
-
-  private:
-	std::vector<T> m_array{};
-
-	friend class Scene;
-};
-
+///
+/// \brief Collection of all ResourceArray instances used by Scene.
+///
 struct SceneResources {
 	ResourceArray<Camera> cameras{};
 	ResourceArray<Sampler> samplers{};

--- a/lib/scene/include/facade/scene/scene_resources.hpp
+++ b/lib/scene/include/facade/scene/scene_resources.hpp
@@ -2,29 +2,48 @@
 #include <facade/scene/camera.hpp>
 #include <facade/scene/material.hpp>
 #include <facade/scene/mesh.hpp>
+#include <facade/util/ptr.hpp>
 #include <facade/vk/static_mesh.hpp>
 #include <facade/vk/texture.hpp>
 #include <span>
 
 namespace facade {
-///
-/// \brief View of the resources stored in the scene.
-///
-template <bool Const>
-struct TSceneResources {
-	template <typename T>
-	using View = std::conditional_t<Const, std::span<T const>, std::span<T>>;
+template <typename T>
+class ResourceArray {
+  public:
+	std::span<T> view() { return m_array; }
+	std::span<T const> view() const { return m_array; }
 
-	View<Camera> cameras{};
-	View<Sampler> samplers{};
-	View<std::unique_ptr<Material>> materials{};
-	View<StaticMesh> static_meshes{};
-	View<Texture> textures{};
-	View<Mesh> meshes{};
+	Ptr<T const> find(Id<T> index) const {
+		if (index >= m_array.size()) { return {}; }
+		return &m_array[index];
+	}
 
-	operator TSceneResources<true>() const { return {cameras, samplers, materials, static_meshes, textures, meshes}; }
+	Ptr<T> find(Id<T> index) { return const_cast<Ptr<T>>(std::as_const(*this).find(index)); }
+
+	T const& operator[](Id<T> index) const {
+		auto ret = find(index);
+		assert(ret);
+		return *ret;
+	}
+
+	T& operator[](Id<T> index) { return const_cast<T&>(std::as_const(*this).operator[](index)); }
+
+	constexpr std::size_t size() const { return m_array.size(); }
+	constexpr bool empty() const { return m_array.empty(); }
+
+  private:
+	std::vector<T> m_array{};
+
+	friend class Scene;
 };
 
-using SceneResources = TSceneResources<true>;
-using SceneResourcesMut = TSceneResources<false>;
+struct SceneResources {
+	ResourceArray<Camera> cameras{};
+	ResourceArray<Sampler> samplers{};
+	ResourceArray<Material> materials{};
+	ResourceArray<StaticMesh> static_meshes{};
+	ResourceArray<Texture> textures{};
+	ResourceArray<Mesh> meshes{};
+};
 } // namespace facade

--- a/lib/scene/src/material.cpp
+++ b/lib/scene/src/material.cpp
@@ -16,15 +16,14 @@ float bit_cast_f(Material::AlphaMode const mode) {
 	std::memcpy(&ret, &mode, sizeof(mode));
 	return ret;
 }
+
+glm::vec4 to_linear(glm::vec4 const& srgb) { return glm::convertSRGBToLinear(srgb); }
 } // namespace
 
 Texture const& TextureStore::get(std::optional<std::size_t> const index, Texture const& fallback) const {
 	if (!index || *index >= textures.size()) { return fallback; }
 	return textures[*index];
 }
-
-glm::vec4 Material::to_linear(glm::vec4 const& srgb) { return glm::convertSRGBToLinear(srgb); }
-glm::vec4 Material::to_srgb(glm::vec4 const& linear) { return glm::convertLinearToSRGB(linear); }
 
 void UnlitMaterial::write_sets(Pipeline& pipeline, TextureStore const& store) const {
 	auto& set1 = pipeline.next_set(1);

--- a/src/gui/main_menu.cpp
+++ b/src/gui/main_menu.cpp
@@ -118,7 +118,7 @@ bool WindowMenu::display_log() {
 bool WindowMenu::display_resources(Scene& scene) {
 	bool show{true};
 	ImGui::SetNextWindowSize({400.0f, 300.0f}, ImGuiCond_FirstUseEver);
-	if (auto window = editor::Window{"Resources", &show}) { editor::SceneInspector{window, scene}.resources(m_data.name_buf); }
+	if (auto window = editor::Window{"Resources", &show}) { editor::SceneInspector{window, scene}.resources(m_data.inspect_data); }
 	return show;
 }
 

--- a/src/gui/main_menu.hpp
+++ b/src/gui/main_menu.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <facade/engine/editor/common.hpp>
+#include <facade/engine/editor/inspect_data.hpp>
 #include <facade/engine/editor/log.hpp>
 #include <facade/engine/editor/scene_tree.hpp>
 #include <gui/events.hpp>
@@ -45,7 +46,7 @@ class WindowMenu : public logger::Accessor {
 	struct {
 		editor::LogState log_state{};
 		editor::InspectNode inspect{};
-		std::string name_buf{};
+		editor::InspectData inspect_data{};
 		Bool unified_scaling{true};
 	} m_data{};
 	struct {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,7 +61,7 @@ void run(AppOpts const& opts) {
 
 		auto material = std::make_unique<LitMaterial>();
 		material->albedo = {1.0f, 0.0f, 0.0f};
-		auto material_id = scene.add(std::move(material));
+		auto material_id = scene.add(Material{std::move(material)});
 		auto static_mesh_id = scene.add(make_cubed_sphere(1.0f, 32));
 		// auto static_mesh_id = scene.add(make_manipulator(0.125f, 1.0f, 16));
 		auto mesh_id = scene.add(Mesh{.primitives = {Mesh::Primitive{static_mesh_id, material_id}}});


### PR DESCRIPTION
- Refactor `SceneResources` to be a single class providing both array ownership and span views.
- Make `Material` a value type.
- Enable choosing between Lit and Unlit materials on Add.
- Separate persistent `InspectData`.
- Add docs.
